### PR TITLE
Fix forward reference rebuilding

### DIFF
--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -192,5 +192,10 @@ class LearningPathState(TypedDict):
     submodule_resources_in_process: Optional[Dict[str, Dict[str, Any]]]  # Tracking submodule resource generation
     
 # Enable forward references for EnhancedModule.submodules
-EnhancedModule.model_rebuild()
-SubmoduleList.model_rebuild()
+# Pydantic <2 uses `update_forward_refs` while >=2 uses `model_rebuild`
+if hasattr(EnhancedModule, "model_rebuild"):
+    EnhancedModule.model_rebuild()
+    SubmoduleList.model_rebuild()
+else:  # pragma: no cover - compatibility for older Pydantic versions
+    EnhancedModule.update_forward_refs()
+    SubmoduleList.update_forward_refs()


### PR DESCRIPTION
## Summary
- gracefully rebuild forward references for different pydantic versions

## Testing
- `pip install cryptography python-dotenv sqlalchemy psycopg2-binary httpx`
- `PYTHONPATH=backend pytest tests/test_key_management.py::TestApiKeyManager::test_google_key_format_validation -q`
- `PYTHONPATH=backend pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68400556cfc4832dba7ac9df9fed5e6b