### PR TITLE
Add offline learning path caching

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'mapmylearn-cache-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)));
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.open(CACHE_NAME).then(cache => {
+      return fetch(event.request)
+        .then(response => {
+          cache.put(event.request, response.clone());
+          return response;
+        })
+        .catch(() => cache.match(event.request));
+    })
+  );
+});

--- a/frontend/src/components/learning-path/hooks/useLearningPathData.js
+++ b/frontend/src/components/learning-path/hooks/useLearningPathData.js
@@ -61,7 +61,7 @@ const useLearningPathData = (source = null) => {
       console.log('useLearningPathData: Starting load...', { taskId, entryId, shareId, shouldLoadFromHistory, shouldLoadPublic, source });
       setLoading(true);
       setError(null);
-      setData(null); 
+      setData(null);
       setTemporaryPathId(null);
       setPersistentPathId(null); // Reset persistentPathId on new load
       setIsFromHistory(false); // Reset isFromHistory
@@ -71,6 +71,23 @@ const useLearningPathData = (source = null) => {
       setLastVisitedSubmoduleIdx(null);
       setIsPublicView(source === 'public' || !!shareId);
       pollingAttemptsRef.current = 0;
+
+      const offlineId = entryId || shareId;
+      if (!navigator.onLine && offlineId) {
+        try {
+          const offlineJson = localStorage.getItem(`offline_learning_path_${offlineId}`);
+          if (offlineJson) {
+            const offlineData = JSON.parse(offlineJson);
+            setData(offlineData);
+            setPersistentPathId(offlineId);
+            setLoading(false);
+            setError(null);
+            return;
+          }
+        } catch (e) {
+          console.error('Error loading offline data:', e);
+        }
+      }
       
       try {
         if (shouldLoadFromHistory) {
@@ -122,6 +139,22 @@ const useLearningPathData = (source = null) => {
         }
       } catch (err) {
         console.error('Error in loadData setup:', err);
+        const offlineId = entryId || shareId;
+        if (offlineId) {
+          try {
+            const offlineJson = localStorage.getItem(`offline_learning_path_${offlineId}`);
+            if (offlineJson) {
+              const offlineData = JSON.parse(offlineJson);
+              setData(offlineData);
+              setPersistentPathId(offlineId);
+              setError(null);
+              setLoading(false);
+              return;
+            }
+          } catch (e) {
+            console.error('Error loading offline data:', e);
+          }
+        }
         setError(err.message || 'Error loading course.');
         setLoading(false);
         cleanup();

--- a/frontend/src/components/learning-path/view/LearningPathHeader.jsx
+++ b/frontend/src/components/learning-path/view/LearningPathHeader.jsx
@@ -28,6 +28,8 @@ import LinkIcon from '@mui/icons-material/Link';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import LockIcon from '@mui/icons-material/Lock';
 import BookmarkAddIcon from '@mui/icons-material/BookmarkAdd';
+import DownloadForOfflineIcon from '@mui/icons-material/DownloadForOffline';
+import DeleteIcon from '@mui/icons-material/Delete';
 import CircularProgress from '@mui/material/CircularProgress';
 import { motion } from 'framer-motion';
 import InfoTooltip from '../../shared/InfoTooltip';
@@ -81,7 +83,10 @@ const LearningPathHeader = ({
   entryId = null,
   isLoggedIn = false,
   onCopyToHistory,
-  isCopying = false
+  isCopying = false,
+  onSaveOffline,
+  onRemoveOffline,
+  isOfflineAvailable = false
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -311,7 +316,7 @@ const LearningPathHeader = ({
                       </Button>
                     </Tooltip>
                   </motion.div>
-                  
+
                   <motion.div variants={buttonVariants} sx={{ flex: 1 }}>
                     <Tooltip title={!isPdfReady ? "PDF download available after generation completes" : "Download as PDF"}>
                       <span>
@@ -329,6 +334,22 @@ const LearningPathHeader = ({
                       </span>
                     </Tooltip>
                   </motion.div>
+
+                  {entryId && (
+                    <motion.div variants={buttonVariants} sx={{ flex: 1 }}>
+                      <Tooltip title={isOfflineAvailable ? "Remove offline copy" : "Save for offline"}>
+                        <Button
+                          variant="outlined"
+                          fullWidth
+                          startIcon={isOfflineAvailable ? <DeleteIcon /> : <DownloadForOfflineIcon />}
+                          onClick={isOfflineAvailable ? onRemoveOffline : onSaveOffline}
+                          size={isMobile ? "small" : "medium"}
+                        >
+                          Offline
+                        </Button>
+                      </Tooltip>
+                    </motion.div>
+                  )}
                 </Box>
                 
                 {!isPublicView && (
@@ -414,6 +435,20 @@ const LearningPathHeader = ({
                     </span>
                   </Tooltip>
                 </motion.div>
+
+                {entryId && (
+                  <motion.div variants={buttonVariants}>
+                    <Tooltip title={isOfflineAvailable ? "Remove offline copy" : "Save for offline"}>
+                      <Button
+                        variant="outlined"
+                        startIcon={isOfflineAvailable ? <DeleteIcon /> : <DownloadForOfflineIcon />}
+                        onClick={isOfflineAvailable ? onRemoveOffline : onSaveOffline}
+                      >
+                        Offline
+                      </Button>
+                    </Tooltip>
+                  </motion.div>
+                )}
                 
                 {!isPublicView && (
                   <motion.div variants={buttonVariants}>
@@ -494,6 +529,9 @@ LearningPathHeader.propTypes = {
   isLoggedIn: PropTypes.bool,
   onCopyToHistory: PropTypes.func,
   isCopying: PropTypes.bool,
+  onSaveOffline: PropTypes.func,
+  onRemoveOffline: PropTypes.func,
+  isOfflineAvailable: PropTypes.bool,
 };
 
 export default LearningPathHeader; 

--- a/frontend/src/components/learning-path/view/LearningPathView.jsx
+++ b/frontend/src/components/learning-path/view/LearningPathView.jsx
@@ -253,7 +253,10 @@ const LearningPathView = ({ source }) => {
     handleDeleteTag,
     handleTagKeyDown,
     handleNotificationClose,
-    showNotification
+    showNotification,
+    handleSaveOffline,
+    handleRemoveOffline,
+    isOfflineAvailable
   } = useLearningPathActions(
     actualPathData, 
     isFromHistory,
@@ -887,10 +890,13 @@ const LearningPathView = ({ source }) => {
                entryId={currentEntryId} 
                isLoggedIn={isAuthenticated} 
                onTogglePublic={() => handleTogglePublic(currentEntryId, !isPublic)} 
-               onCopyShareLink={handleCopyShareLink} 
-               onCopyToHistory={handleCopyToHistory} 
-               isCopying={isCopying} 
-             />
+              onCopyShareLink={handleCopyShareLink}
+              onCopyToHistory={handleCopyToHistory}
+              isCopying={isCopying}
+              onSaveOffline={handleSaveOffline}
+              onRemoveOffline={handleRemoveOffline}
+              isOfflineAvailable={isOfflineAvailable}
+            />
              {/* --- NEW: Topic Resources Section --- */}
               {topicResources && topicResources.length > 0 && (
                 <Box sx={{ mt: 2 }} data-tut="topic-resources-section">

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -25,3 +25,10 @@ root.render(
     </HelmetProvider>
   </React.StrictMode>
 ); 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js').catch(err => {
+      console.log('Service worker registration failed:', err);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple service worker for offline caching
- register service worker in the React entry point
- allow saving and removing learning paths to localStorage
- show offline save/remove buttons in the course header
- load cached learning paths when network is unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv, langchain_core, psycopg2, sqlalchemy, httpx, cryptography)*

------
https://chatgpt.com/codex/tasks/task_e_684d199b9fd4832d94002e43d56db6ed