### PR TITLE
Add PWA support with service worker

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,6 +9,7 @@
       content="MapMyLearn - AI-Powered Course Generator"
     />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "short_name": "MapMyLearn",
+  "name": "MapMyLearn - Course Generator",
+  "icons": [
+    {
+      "src": "logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,54 @@
+const CACHE_NAME = 'mml-cache-v1';
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/offline'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  const req = event.request;
+  if (req.mode === 'navigate') {
+    event.respondWith(
+      fetch(req)
+        .then(res => {
+          caches.open(CACHE_NAME).then(cache => cache.put('/index.html', res.clone()));
+          return res;
+        })
+        .catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+  if (req.url.endsWith('.js')) {
+    event.respondWith(
+      caches.match(req).then(cached => {
+        const fetchPromise = fetch(req)
+          .then(res => {
+            if (res && res.status === 200) {
+              const clone = res.clone();
+              caches.open(CACHE_NAME).then(cache => cache.put(req, clone));
+            }
+            return res;
+          })
+          .catch(() => cached);
+        return cached || fetchPromise;
+      })
+    );
+  }
+});

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,7 @@ import App from './App';
 import './index.css';
 import './utils/animations.css';
 import { initializeSanitizer } from './utils/sanitizer';
+import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 
 // Initialize content sanitization with PrismJS vulnerability protection
 initializeSanitizer();
@@ -24,4 +25,6 @@ root.render(
       </BrowserRouter>
     </HelmetProvider>
   </React.StrictMode>
-); 
+);
+
+serviceWorkerRegistration.register();

--- a/frontend/src/serviceWorkerRegistration.js
+++ b/frontend/src/serviceWorkerRegistration.js
@@ -1,0 +1,15 @@
+export function register() {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .catch(err => console.error('Service worker registration failed:', err));
+    });
+  }
+}
+
+export function unregister() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready.then(reg => reg.unregister());
+  }
+}


### PR DESCRIPTION
## Summary
- create `manifest.json` with app info and icons
- add service worker for offline caching
- register the worker in React entry
- remove duplicate `logo.png` file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv, langchain_core, psycopg2, sqlalchemy, httpx, cryptography)*
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d21cf3b1c832da71a2890882f553a