### PR TITLE
Add PWA intro modal

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { Container, Box } from '@mui/material';
+import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { Analytics } from "@vercel/analytics/react";
 
 // Import components
@@ -21,6 +21,8 @@ import routesConfig from './routesConfig';
 
 // Import new components
 import WelcomeModal from './components/shared/WelcomeModal';
+import PwaIntroModal from './components/shared/PwaIntroModal';
+import PwaIntroContext from './contexts/PwaIntroContext';
 
 // Import the theme
 import theme from './theme/theme';
@@ -30,11 +32,29 @@ import GeneratingPage from './pages/GeneratingPage';
 // --- End import ---
 
 // New component to render routes and modal
+const PWA_FLAG_KEY = 'mapmylearn_pwa_intro_shown';
+
 const AppContent = () => {
   const { showWelcomeModal, markWelcomeModalShown } = useAuth();
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const [showPwaIntro, setShowPwaIntro] = useState(false);
+
+  useEffect(() => {
+    if (isSmallScreen && !localStorage.getItem(PWA_FLAG_KEY)) {
+      setShowPwaIntro(true);
+    }
+  }, [isSmallScreen]);
+
+  const handleClosePwaIntro = () => {
+    localStorage.setItem(PWA_FLAG_KEY, 'true');
+    setShowPwaIntro(false);
+  };
+
+  const openPwaIntro = () => setShowPwaIntro(true);
 
   return (
-    <>
+    <PwaIntroContext.Provider value={{ openPwaIntro }}>
       <Box sx={{ flexGrow: 1 }}>
         <Routes>
           {routesConfig.map((route, index) => {
@@ -79,7 +99,8 @@ const AppContent = () => {
         </Routes>
       </Box>
       <WelcomeModal open={showWelcomeModal} onClose={markWelcomeModalShown} />
-    </>
+      <PwaIntroModal open={showPwaIntro} onClose={handleClosePwaIntro} />
+    </PwaIntroContext.Provider>
   );
 }
 

--- a/frontend/src/components/shared/PwaIntroModal.jsx
+++ b/frontend/src/components/shared/PwaIntroModal.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Stepper,
+  Step,
+  StepLabel,
+  useTheme,
+  useMediaQuery
+} from '@mui/material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import { helpTexts } from '../../constants/helpTexts';
+
+const steps = [
+  { label: 'Install', contentKey: 'pwaInstall' },
+  { label: 'Offline', contentKey: 'pwaOfflineUsage' }
+];
+
+const PwaIntroModal = ({ open, onClose }) => {
+  const [activeStep, setActiveStep] = useState(0);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const handleNext = () => setActiveStep((prev) => prev + 1);
+  const handleBack = () => setActiveStep((prev) => prev - 1);
+  const handleClose = () => {
+    onClose();
+    setTimeout(() => setActiveStep(0), 300);
+  };
+
+  const currentContent = helpTexts[steps[activeStep].contentKey];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={(event, reason) => {
+        if (reason !== 'backdropClick' && reason !== 'escapeKeyDown') {
+          handleClose();
+        }
+      }}
+      maxWidth="sm"
+      fullWidth
+      TransitionProps={{ onExited: () => setActiveStep(0) }}
+    >
+      <DialogTitle sx={{ textAlign: 'center', pt: 3 }}>
+        {helpTexts.pwaIntroTitle}
+      </DialogTitle>
+      <DialogContent sx={{ textAlign: 'center', minHeight: '150px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Typography variant="h6" color="text.secondary">
+          {currentContent}
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ p: 2, flexDirection: 'column', alignItems: 'center' }}>
+        <Stepper activeStep={activeStep} alternativeLabel={isMobile} sx={{ width: '100%', mb: 2 }}>
+          {steps.map((step) => (
+            <Step key={step.label}>
+              <StepLabel sx={{ '.MuiStepLabel-label': { fontSize: '0.8rem' } }} />
+            </Step>
+          ))}
+        </Stepper>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+          <Button onClick={handleBack} disabled={activeStep === 0} startIcon={<NavigateBeforeIcon />}>Back</Button>
+          {activeStep === steps.length - 1 ? (
+            <Button variant="contained" onClick={handleClose} color="primary">
+              {helpTexts.pwaIntroGotIt}
+            </Button>
+          ) : (
+            <Button variant="contained" onClick={handleNext} endIcon={<NavigateNextIcon />}>Next</Button>
+          )}
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+PwaIntroModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default PwaIntroModal;

--- a/frontend/src/components/shared/PwaIntroModal.jsx
+++ b/frontend/src/components/shared/PwaIntroModal.jsx
@@ -61,7 +61,7 @@ const PwaIntroModal = ({ open, onClose }) => {
         <Stepper activeStep={activeStep} alternativeLabel={isMobile} sx={{ width: '100%', mb: 2 }}>
           {steps.map((step) => (
             <Step key={step.label}>
-              <StepLabel sx={{ '.MuiStepLabel-label': { fontSize: '0.8rem' } }} />
+              <StepLabel sx={{ '.MuiStepLabel-label': { fontSize: '0.8rem' } }}>{step.label}</StepLabel>
             </Step>
           ))}
         </Stepper>

--- a/frontend/src/components/shared/WelcomeModal.jsx
+++ b/frontend/src/components/shared/WelcomeModal.jsx
@@ -84,7 +84,7 @@ const WelcomeModal = ({ open, onClose }) => {
         <Stepper activeStep={activeStep} alternativeLabel={isMobile} sx={{ width: '100%', mb: 2 }}>
           {steps.map((step, index) => (
             <Step key={step.label}>
-              <StepLabel sx={{ '.MuiStepLabel-label': { fontSize: '0.8rem' } }} />
+              <StepLabel sx={{ '.MuiStepLabel-label': { fontSize: '0.8rem' } }}>{step.label}</StepLabel>
             </Step>
           ))}
         </Stepper>

--- a/frontend/src/constants/helpTexts.js
+++ b/frontend/src/constants/helpTexts.js
@@ -35,6 +35,12 @@ export const helpTexts = {
   submoduleTabAudio: (cost) => `Generate a spoken audio summary of this content (costs ${cost} credit).`,
   submoduleTabVisualization: (cost) => `Generate an interactive diagram of this submodule's content (costs ${cost} credit).`,
 
+  // PWA Intro Modal
+  pwaIntroTitle: "MapMyLearn on your device",
+  pwaInstall: "Install the app from your browser menu for a full-screen experience.",
+  pwaOfflineUsage: "Use the Offline page to access saved courses without an internet connection.",
+  pwaIntroGotIt: "Got it!",
+
   // Tooltip Defaults
   defaultInfoAlt: "More information",
-}; 
+};

--- a/frontend/src/contexts/PwaIntroContext.js
+++ b/frontend/src/contexts/PwaIntroContext.js
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+const PwaIntroContext = createContext(null);
+
+export const usePwaIntro = () => {
+  const context = useContext(PwaIntroContext);
+  if (!context) {
+    throw new Error('usePwaIntro must be used within a PwaIntroContext provider');
+  }
+  return context;
+};
+
+export default PwaIntroContext;

--- a/frontend/src/pages/OfflinePage/index.js
+++ b/frontend/src/pages/OfflinePage/index.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, List, ListItem, ListItemButton, ListItemText, Divider, IconButton } from '@mui/material';
+import { Box, Typography, List, ListItem, ListItemButton, ListItemText, Divider, IconButton, Button } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Link as RouterLink } from 'react-router';
 import { getOfflinePaths, removeOfflinePath } from '../../services/offlineService';
+import { usePwaIntro } from '../../contexts/PwaIntroContext';
 
 const OfflinePage = () => {
   const [paths, setPaths] = useState([]);
+  const { openPwaIntro } = usePwaIntro();
 
   useEffect(() => {
     const data = getOfflinePaths();
@@ -20,9 +22,14 @@ const OfflinePage = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Typography variant="h5" gutterBottom>
-        Offline Learning Paths
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+        <Typography variant="h5" gutterBottom sx={{ mr: 2 }}>
+          Offline Learning Paths
+        </Typography>
+        <Button size="small" variant="outlined" onClick={openPwaIntro}>
+          App Tips
+        </Button>
+      </Box>
       {paths.length === 0 ? (
         <Typography>No offline courses saved.</Typography>
       ) : (


### PR DESCRIPTION
## Summary
- create PwaIntroModal component
- add help text describing PWA install and offline usage
- manage showPwaIntro state in App with context
- provide a button in Offline page to reopen modal

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bbf4fb40832da58c26058b19f3c9