### PR TITLE
Enable language selection for mermaid visualizations

### DIFF
--- a/backend/prompts/visualization_prompts.py
+++ b/backend/prompts/visualization_prompts.py
@@ -8,7 +8,7 @@ for interactive visualizations of submodule content.
 MERMAID_VISUALIZATION_PROMPT = """\
 You are an expert data visualizer and instructional designer specializing in educational diagrams.
 
-Your task is to generate Mermaid.js syntax for an interactive and intuitive diagram. Follow these guidelines closely before analyzing the submodule content.
+Your task is to generate Mermaid.js syntax for an interactive and intuitive diagram. Follow these guidelines closely before analyzing the submodule content. All node labels and text should be written in {language}.
 
 ## Instructions:
 

--- a/backend/routes/learning_paths.py
+++ b/backend/routes/learning_paths.py
@@ -49,7 +49,9 @@ logger = logging.getLogger(__name__) # Add logger instance
 
 # Define supported languages
 SUPPORTED_AUDIO_LANGUAGES = ["en", "es", "fr", "de", "it", "pt"]
+SUPPORTED_VISUALIZATION_LANGUAGES = ["en", "es", "fr", "de", "it", "pt"]
 DEFAULT_AUDIO_LANGUAGE = "en" # Although we expect frontend to always send it
+DEFAULT_VISUALIZATION_LANGUAGE = "en"
 
 @router.get("", response_model=LearningPathList)
 async def get_learning_paths(
@@ -1086,6 +1088,13 @@ async def generate_submodule_visualization_endpoint(
     """
     logger.info(f"Visualization request for path {path_id}, M{module_index}, S{submodule_index} by user {user.id}")
 
+    requested_language = request_data.language or DEFAULT_VISUALIZATION_LANGUAGE
+    if requested_language not in SUPPORTED_VISUALIZATION_LANGUAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported language '{requested_language}'. Supported languages are: {SUPPORTED_VISUALIZATION_LANGUAGES}"
+        )
+
     # --- TEMP DEBUG: Print TransactionType attributes ---
     import inspect
     logger.info("DEBUG: Available TransactionType attributes:")
@@ -1193,6 +1202,7 @@ async def generate_submodule_visualization_endpoint(
             submodule_title=submodule_title,
             submodule_description=submodule_description,
             submodule_content=submodule_content,
+            language=requested_language,
             google_key_provider=google_key_provider,
             user=user
         )

--- a/backend/schemas/auth_schemas.py
+++ b/backend/schemas/auth_schemas.py
@@ -277,6 +277,7 @@ class GenerateAudioResponse(BaseModel):
 class GenerateVisualizationRequest(BaseModel):
     """Request body for generating interactive visualizations."""
     path_data: Optional[Dict[str, Any]] = Field(None, description="Full path_data if the course is temporary and not yet saved to history")
+    language: str = Field(..., description="ISO language code like 'en', 'es'")
 
 
 class GenerateVisualizationResponse(BaseModel):

--- a/backend/services/visualization_service.py
+++ b/backend/services/visualization_service.py
@@ -14,6 +14,7 @@ async def generate_mermaid_visualization(
     submodule_title: str,
     submodule_description: str,
     submodule_content: str,
+    language: str,
     google_key_provider: Optional[Any] = None,
     user: Optional[Any] = None  # Add user parameter for model selection
 ) -> Dict[str, Optional[str]]:
@@ -24,6 +25,7 @@ async def generate_mermaid_visualization(
         submodule_title: The title of the submodule
         submodule_description: The description of the submodule  
         submodule_content: The main content of the submodule
+        language: Target language for diagram labels (ISO code)
         google_key_provider: Optional key provider for Google API
         user: Optional user parameter for model selection
         
@@ -49,6 +51,7 @@ async def generate_mermaid_visualization(
             "submodule_title": submodule_title,
             "submodule_description": submodule_description or "No description provided",
             "submodule_content": submodule_content[:15000],  # Limit content length for LLM
+            "language": language,
         })
 
         # Try to parse as JSON first (for "not suitable" message)

--- a/frontend/src/components/learning-path/view/ContentPanel.jsx
+++ b/frontend/src/components/learning-path/view/ContentPanel.jsx
@@ -172,12 +172,14 @@ const ContentPanel = forwardRef(({
   }, [actualPathData?.language]);
 
   const [selectedLanguage, setSelectedLanguage] = useState(getInitialLanguage);
+  const [selectedVizLanguage, setSelectedVizLanguage] = useState(getInitialLanguage);
 
   useEffect(() => {
     if (displayType === 'submodule' && submodule) {
       setAudioUrl(getAbsoluteAudioUrl(submodule?.audio_url));
       setSelectedLanguage(getInitialLanguage());
-      setAudioError(null); 
+      setSelectedVizLanguage(getInitialLanguage());
+      setAudioError(null);
       // Clear visualization state
       setMermaidSyntax(null);
       setVisualizationError(null);
@@ -191,6 +193,7 @@ const ContentPanel = forwardRef(({
       setVisualizationError(null);
       setVisualizationMessage(null);
       setIsVisualizationLoading(false);
+      setSelectedVizLanguage(getInitialLanguage());
     }
   }, [submodule, displayType, getAbsoluteAudioUrl, getInitialLanguage]);
 
@@ -251,7 +254,12 @@ const ContentPanel = forwardRef(({
   
   const handleLanguageChange = (event) => {
     setSelectedLanguage(event.target.value);
-    setAudioError(null); 
+    setAudioError(null);
+  };
+
+  const handleVizLanguageChange = (event) => {
+    setSelectedVizLanguage(event.target.value);
+    setVisualizationError(null);
   };
 
   const handleAudioStyleChange = (event) => {
@@ -278,7 +286,7 @@ const ContentPanel = forwardRef(({
       console.log('Generating visualization for submodule:', submodule.title);
 
       // Determine request data based on path type (temporary vs persisted)
-      const requestData = isTemporaryPath && actualPathData ? { path_data: actualPathData } : {};
+      const requestData = isTemporaryPath && actualPathData ? { path_data: actualPathData, language: selectedVizLanguage } : { language: selectedVizLanguage };
 
       const response = await generateSubmoduleVisualization(
         pathId,
@@ -646,9 +654,25 @@ const ContentPanel = forwardRef(({
                              </Button>
                          </Box>
                      )}
-                     {tab.component === 'Visualization' && (
-                         <Box data-tut="content-panel-tab-visualization" sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 2.5, p: { xs: 2, sm: 3 } }}>
-                             {isVisualizationLoading && <CircularProgress sx={{ my: 2, alignSelf: 'center' }} />}
+                    {tab.component === 'Visualization' && (
+                        <Box data-tut="content-panel-tab-visualization" sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 2.5, p: { xs: 2, sm: 3 } }}>
+                            <FormControl fullWidth sx={{ maxWidth: '300px' }} disabled={isVisualizationLoading}>
+                                <InputLabel id={`viz-language-select-label`}>Diagram Language</InputLabel>
+                                <Select
+                                    labelId={`viz-language-select-label`}
+                                    value={selectedVizLanguage}
+                                    label="Diagram Language"
+                                    onChange={handleVizLanguageChange}
+                                    variant="outlined"
+                                    size="small"
+                                >
+                                    {supportedLanguages.map((lang) => (
+                                        <MenuItem key={lang.code} value={lang.code}>{lang.name}</MenuItem>
+                                    ))}
+                                </Select>
+                                <FormHelperText>Language used for visualization labels.</FormHelperText>
+                            </FormControl>
+                            {isVisualizationLoading && <CircularProgress sx={{ my: 2, alignSelf: 'center' }} />}
                              {visualizationError && !isVisualizationLoading && <Alert severity="error" sx={{ width: '100%', mb: 1 }}>{visualizationError}</Alert>}
                              {visualizationMessage && !isVisualizationLoading && <Alert severity="info" sx={{ width: '100%', mb: 1 }}>{visualizationMessage}</Alert>}
                              

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1114,7 +1114,7 @@ export const purchaseChatAllowance = async () => {
  * @param {string} pathId - The ID of the course (can be temporary task ID or persistent UUID)
  * @param {number} moduleIndex - Zero-based index of the module
  * @param {number} submoduleIndex - Zero-based index of the submodule
- * @param {object} requestData - The request data including optional path_data for temporary paths
+ * @param {object} requestData - The request data including optional path_data for temporary paths and the diagram language
  * @returns {Promise<object>} The API response containing mermaid_syntax or error message
  */
 export const generateSubmoduleVisualization = async (pathId, moduleIndex, submoduleIndex, requestData) => {


### PR DESCRIPTION
## Summary
- allow selecting language when generating Mermaid diagrams
- support the language field in backend visualization APIs
- update visualization prompt and service
- add UI dropdown for diagram language

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: dotenv, langchain_core, psycopg2, sqlalchemy, httpx, cryptography)*

------
https://chatgpt.com/codex/tasks/task_e_6853f9f00524832d96ac119ada4f5cc7