### PR TITLE
Improve generation progress reliability

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -709,6 +709,15 @@ async def generate_learning_path_task(
             else:
                 if last_id == 0:
                     last_id = 1
+                # Cache the latest event id even if the task isn't in memory yet
+                active_generations[task_id] = {
+                    "status": "running",
+                    "result": None,
+                    "user_id": user_id,
+                    "progress_stream": [],
+                    "error": None,
+                    "last_event_id": last_id,
+                }
                 logger.warning(
                     f"Task {task_id} not found in active_generations when trying to append progress."
                 )

--- a/frontend/src/components/learning-path/hooks/useProgressTracking.js
+++ b/frontend/src/components/learning-path/hooks/useProgressTracking.js
@@ -422,9 +422,16 @@ const useProgressTracking = (taskId, onTaskComplete) => {
   
   const eventIdKey = `lastEventId-${taskId}`;
   const storedLive = sessionStorage.getItem(`liveBuildData-${taskId}`);
+  let initialState;
+  try {
+    initialState = storedLive ? JSON.parse(storedLive) : initialLiveBuildData;
+  } catch (err) {
+    console.error('Failed to parse stored live build data', err);
+    initialState = initialLiveBuildData;
+  }
   const [liveBuildData, dispatchLiveBuildDataUpdate] = useReducer(
     liveBuildDataReducer,
-    storedLive ? JSON.parse(storedLive) : initialLiveBuildData
+    initialState
   );
   const lastEventIdRef = useRef(parseInt(sessionStorage.getItem(eventIdKey)) || 0);
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1224,7 +1224,7 @@ export const copyPublicPath = async (shareId) => {
 };
 
 // --- NEW: Function to stream progress updates via SSE --- 
-export const streamProgressUpdates = (taskId, onMessage, onError, onClose) => {
+export const streamProgressUpdates = (taskId, onMessage, onError, onClose, lastEventId = 0) => {
   if (!taskId) {
     if (onError) onError(new Error("Task ID is required for progress updates."));
     return null; // Or throw error, depending on desired strictness
@@ -1241,7 +1241,9 @@ export const streamProgressUpdates = (taskId, onMessage, onError, onClose) => {
   //   ? `${API_URL}/api/learning-path/${taskId}/progress-stream?token=${authToken}` 
   //   : `${API_URL}/api/learning-path/${taskId}/progress-stream`;
   // Simpler approach for now, assuming cookie-based auth or public endpoint for SSE if no token passed in query
-  const sseUrl = `${API_URL}/api/learning-path/${taskId}/progress-stream`;
+  const sseUrl = lastEventId
+    ? `${API_URL}/api/learning-path/${taskId}/progress-stream?lastEventId=${lastEventId}`
+    : `${API_URL}/api/learning-path/${taskId}/progress-stream`;
 
   console.log(`Connecting to SSE: ${sseUrl}`);
   const eventSource = new EventSource(sseUrl, { withCredentials: true }); // Added withCredentials for cookie-based auth

--- a/tests/test_progress_persistence.py
+++ b/tests/test_progress_persistence.py
@@ -17,6 +17,10 @@ class DummyRedis:
         else:
             end += 1
         return data[start:end]
+    async def incr(self, key):
+        val = int(self.store.get(key, 0)) + 1
+        self.store[key] = val
+        return val
     async def expire(self, key, ttl):
         pass
     async def ping(self):

--- a/tests/test_progress_persistence.py
+++ b/tests/test_progress_persistence.py
@@ -23,7 +23,12 @@ class DummyRedis:
         return True
 
 def async_run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    """Run an async coroutine in a fresh event loop for isolation."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 def test_save_progress_to_redis():
     redis = DummyRedis()

--- a/tests/test_progress_persistence.py
+++ b/tests/test_progress_persistence.py
@@ -1,0 +1,50 @@
+import asyncio
+import json
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from backend.api import app, save_progress_event, active_generations, active_generations_lock
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+    async def rpush(self, key, value):
+        self.store.setdefault(key, []).append(value)
+    async def lrange(self, key, start, end):
+        data = self.store.get(key, [])
+        if end == -1:
+            end = None
+        else:
+            end += 1
+        return data[start:end]
+    async def expire(self, key, ttl):
+        pass
+    async def ping(self):
+        return True
+
+def async_run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+def test_save_progress_to_redis():
+    redis = DummyRedis()
+    async def fake_get():
+        return redis
+    with patch('backend.api.get_redis_client', fake_get):
+        async_run(save_progress_event('task123', {'message':'hi'}, 1))
+        assert json.loads(redis.store['progress:task123'][0])['message'] == 'hi'
+
+def test_last_event_id_resume():
+    redis = DummyRedis()
+    async def fake_get():
+        return redis
+    # preload events
+    async_run(redis.rpush('progress:taskx', json.dumps({'id':1,'message':'one'})))
+    async_run(redis.rpush('progress:taskx', json.dumps({'id':2,'message':'two'})))
+    with patch('backend.api.get_redis_client', fake_get):
+        async_run(active_generations_lock.acquire())
+        active_generations['taskx'] = {'status':'completed','progress_stream':[], 'last_event_id':2}
+        active_generations_lock.release()
+        client = TestClient(app)
+        resp = client.get('/api/learning-path/taskx/progress-stream', headers={'Last-Event-ID':'1'})
+        body = resp.content.decode()
+        assert 'two' in body and 'one' not in body


### PR DESCRIPTION
## Summary
- persist progress updates to Redis and expose an endpoint to fetch them
- send incremental SSE IDs and allow resuming with `Last-Event-ID`
- store latest progress in the browser and resume EventSource when reloading
- add regression tests for progress persistence

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685567035ca0832d956cd6d2044ba469