### PR TITLE
Fix language handling in prompts

### DIFF
--- a/backend/core/graph_nodes/initial_flow.py
+++ b/backend/core/graph_nodes/initial_flow.py
@@ -55,8 +55,11 @@ async def generate_search_queries(state: LearningPathState) -> Dict[str, Any]:
         )
     
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Improved prompt template with better structure and formatting
     prompt_text = """# EXPERT LEARNING PATH ARCHITECT & CURRICULUM DESIGNER
@@ -266,8 +269,11 @@ async def regenerate_initial_structure_query(
     logging.info(f"Regenerating structure query after no results for: {failed_query.keywords}")
     
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Get Google key provider from state
     google_key_provider = state.get("google_key_provider")
@@ -561,7 +567,9 @@ async def create_learning_path(state: LearningPathState) -> Dict[str, Any]:
         logging.debug("Found Google key provider in state, using for course creation")
 
     # Get language information from state
-    output_language = state.get('language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
 
     # Get explanation style
     style = state.get('explanation_style', 'standard')

--- a/backend/core/graph_nodes/research_evaluation.py
+++ b/backend/core/graph_nodes/research_evaluation.py
@@ -397,7 +397,9 @@ async def analyze_research_completeness(state: LearningPathState) -> ResearchEva
     search_context = format_search_results_for_evaluation(search_results)
     
     # Get language settings
-    output_language = state.get('language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     
     # Import the prompt (will be defined in prompts file)
     from backend.prompts.learning_path_prompts import RESEARCH_EVALUATION_PROMPT
@@ -432,8 +434,11 @@ async def create_targeted_queries(state: LearningPathState, knowledge_gaps: List
         existing_queries = [q.keywords for q in state['search_queries']]
     
     # Get language settings
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Import the prompt
     from backend.prompts.learning_path_prompts import REFINEMENT_QUERY_GENERATION_PROMPT

--- a/backend/core/graph_nodes/resources.py
+++ b/backend/core/graph_nodes/resources.py
@@ -68,8 +68,11 @@ async def generate_topic_resources(state: LearningPathState) -> Dict[str, Any]:
 
     try:
         # Get language information
-        output_language = state.get('language', 'en')
-        search_language = state.get('search_language', 'en')
+        from backend.utils.language_utils import get_full_language_name
+        output_language_code = state.get('language', 'en')
+        search_language_code = state.get('search_language', 'en')
+        output_language = get_full_language_name(output_language_code)
+        search_language = get_full_language_name(search_language_code)
         escaped_topic = escape_curly_braces(state["user_topic"])
 
         # Build course context (same logic as before)
@@ -282,8 +285,11 @@ async def generate_module_resources(state: LearningPathState, module_id: int, mo
 
     try:
         # Get language information
-        output_language = state.get('language', 'en')
-        search_language = state.get('search_language', 'en')
+        from backend.utils.language_utils import get_full_language_name
+        output_language_code = state.get('language', 'en')
+        search_language_code = state.get('search_language', 'en')
+        output_language = get_full_language_name(output_language_code)
+        search_language = get_full_language_name(search_language_code)
         escaped_topic = escape_curly_braces(state["user_topic"])
 
         # Build course context (same as before)
@@ -515,8 +521,11 @@ async def generate_submodule_resources(
 
     try:
         # Get language information
-        output_language = state.get('language', 'en')
-        search_language = state.get('search_language', 'en')
+        from backend.utils.language_utils import get_full_language_name
+        output_language_code = state.get('language', 'en')
+        search_language_code = state.get('search_language', 'en')
+        output_language = get_full_language_name(output_language_code)
+        search_language = get_full_language_name(search_language_code)
         escaped_topic = escape_curly_braces(state["user_topic"])
 
         # Build context (similar logic as before)
@@ -1088,8 +1097,11 @@ async def regenerate_resource_query(
     logger.info(f"Regenerating {target_level} resource query after no results for: {failed_query.query}")
     
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Get Google key provider from state
     google_key_provider = state.get("google_key_provider")

--- a/backend/core/graph_nodes/submodules.py
+++ b/backend/core/graph_nodes/submodules.py
@@ -70,8 +70,11 @@ async def regenerate_submodule_content_query(
     logger.info(f"Regenerating submodule content query after no results for: {failed_query.keywords}")
     
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Get Google key provider from state
     google_key_provider = state.get("google_key_provider")
@@ -345,7 +348,9 @@ async def plan_module_submodules(state: LearningPathState, idx: int, module) -> 
         )
     
     # Get language from state
-    output_language = state.get('language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     
     learning_path_context = "\n".join([f"Module {i+1}: {mod.title}\n{mod.description}" 
                                        for i, mod in enumerate(state["modules"])])
@@ -1173,8 +1178,11 @@ async def generate_submodule_specific_queries(
         )
     
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Import función para escapar llaves
     from backend.core.graph_nodes.helpers import escape_curly_braces
@@ -1437,7 +1445,9 @@ async def develop_submodule_specific_content(
     logger.info(f"Developing enhanced content for submodule: {submodule.title}")
 
     # Get language and style settings
-    output_language = state.get('language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     style = state.get('explanation_style', 'standard')
 
     # Enhanced style descriptions with length guidance
@@ -1564,7 +1574,9 @@ async def generate_submodule_quiz(
             )
         
         # Get output language from state
-        output_language = state.get('language', 'en')
+        from backend.utils.language_utils import get_full_language_name
+        output_language_code = state.get('language', 'en')
+        output_language = get_full_language_name(output_language_code)
         
         # Import escape function from helpers
         from backend.core.graph_nodes.helpers import escape_curly_braces
@@ -1966,9 +1978,12 @@ async def generate_module_specific_planning_queries(state: LearningPathState, mo
     logger.info(f"Generating structural planning queries for module {module_id+1}: {module.title}")
 
     # Get providers and language settings
+    from backend.utils.language_utils import get_full_language_name
     google_key_provider = state.get("google_key_provider")
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
 
     # Prepare context
     user_topic = escape_curly_braces(state["user_topic"])
@@ -2028,8 +2043,11 @@ async def regenerate_module_planning_query(
     logger.info(f"Regenerating module planning query for module {module_id+1} after no results for: {failed_query.keywords}")
 
     # Get language information from state
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
 
     # Get Google key provider from state
     google_key_provider = state.get("google_key_provider")
@@ -2364,7 +2382,9 @@ async def plan_module_submodules(
         )
         
     # Get language from state
-    output_language = state.get('language', 'en')
+    from backend.utils.language_utils import get_full_language_name
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     
     # Prepare context
     learning_path_context = "\n".join([f"Module {i+1}: {m.title}\n{m.description}"
@@ -2716,9 +2736,12 @@ async def generate_content_refinement_queries_local(
     logger.info(f"Generating content refinement queries for submodule {module_id+1}.{sub_id+1}: {submodule.title}")
     
     # Get key providers and language settings
+    from backend.utils.language_utils import get_full_language_name
     google_key_provider = state.get("google_key_provider")
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Import necessary components
     from backend.prompts.learning_path_prompts import CONTENT_REFINEMENT_QUERY_GENERATION_PROMPT
@@ -2960,8 +2983,10 @@ async def develop_enhanced_content(
     logger.info(f"Enhancing content for submodule {module_id+1}.{sub_id+1}: {submodule.title}")
     
     # Get key providers and language settings
+    from backend.utils.language_utils import get_full_language_name
     google_key_provider = state.get("google_key_provider")
-    output_language = state.get('language', 'en')
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     explanation_style = state.get('explanation_style', 'standard')
     
     # Import necessary components
@@ -3109,8 +3134,10 @@ async def evaluate_content_sufficiency(
     logger.info(f"Evaluating content sufficiency for submodule {module_id+1}.{sub_id+1}: {submodule.title}")
     
     # Get key providers and language settings
+    from backend.utils.language_utils import get_full_language_name
     google_key_provider = state.get("google_key_provider")
-    output_language = state.get('language', 'en')
+    output_language_code = state.get('language', 'en')
+    output_language = get_full_language_name(output_language_code)
     explanation_style = state.get('explanation_style', 'standard')
     
     # Import necessary components
@@ -3208,9 +3235,12 @@ async def generate_content_refinement_queries(
     logger.info(f"Generating content refinement queries for submodule {module_id+1}.{sub_id+1}: {submodule.title}")
     
     # Get key providers and language settings
+    from backend.utils.language_utils import get_full_language_name
     google_key_provider = state.get("google_key_provider")
-    output_language = state.get('language', 'en')
-    search_language = state.get('search_language', 'en')
+    output_language_code = state.get('language', 'en')
+    search_language_code = state.get('search_language', 'en')
+    output_language = get_full_language_name(output_language_code)
+    search_language = get_full_language_name(search_language_code)
     
     # Import necessary components
     from backend.prompts.learning_path_prompts import CONTENT_REFINEMENT_QUERY_GENERATION_PROMPT

--- a/backend/routes/chatbot.py
+++ b/backend/routes/chatbot.py
@@ -58,52 +58,7 @@ except ValueError:
     CHAT_FREE_LIMIT_PER_DAY = 100
 
 # --- Helper function to convert language code to full language name --- #
-def get_full_language_name(language_code):
-    """
-    Convert an ISO 639-1 language code to its full language name.
-    """
-    language_map = {
-        "en": "English",
-        "es": "Spanish",
-        "fr": "French",
-        "de": "German",
-        "it": "Italian",
-        "pt": "Portuguese",
-        "ru": "Russian",
-        "zh": "Chinese",
-        "ja": "Japanese",
-        "ko": "Korean",
-        "ar": "Arabic",
-        "hi": "Hindi",
-        "bn": "Bengali",
-        "pa": "Punjabi",
-        "jv": "Javanese",
-        "id": "Indonesian",
-        "tr": "Turkish",
-        "vi": "Vietnamese",
-        "pl": "Polish",
-        "uk": "Ukrainian",
-        "nl": "Dutch",
-        "el": "Greek",
-        "cs": "Czech",
-        "sv": "Swedish",
-        "hu": "Hungarian",
-        "fi": "Finnish",
-        "no": "Norwegian",
-        "da": "Danish",
-        "th": "Thai",
-        "he": "Hebrew",
-        "ca": "Catalan"
-    }
-    
-    # Handle more specific language codes with regions (e.g., "pt-BR")
-    if "-" in language_code:
-        base_code = language_code.split("-")[0]
-        if base_code in language_map:
-            return language_map[base_code]
-    
-    # Return the full name if found in the map, otherwise return the original code
-    return language_map.get(language_code, language_code)
+from backend.utils.language_utils import get_full_language_name
 
 # --- Helper function to format path structure --- #
 def format_path_structure(path_data):

--- a/backend/services/audio_service.py
+++ b/backend/services/audio_service.py
@@ -148,6 +148,9 @@ async def generate_submodule_audio(
     concatenation, and database updates if applicable.
     Respects the force_regenerate flag to bypass cache checks.
     """
+    from backend.utils.language_utils import get_full_language_name
+    language_name = get_full_language_name(language)
+
     # --- Validate Language ---
     if language not in AUDIO_SCRIPT_PROMPTS_BY_LANG:
          logger.error(f"Unsupported language requested for audio generation: {language}")
@@ -306,7 +309,7 @@ async def generate_submodule_audio(
     instruction_text = (
         f"Base Persona: Act as an {TTS_PERSONA} explaining '{submodule_title}' to a learner. "
         f"Base Tone/Pacing: Maintain a {Tts_tone} tone. Speak clearly at a {Tts_pacing}. Use natural speech patterns and {Tts_intonation}. "
-        f"Language/Accent: Ensure accurate pronunciation using a {target_accent} in the {language} language. "
+        f"Language/Accent: Ensure accurate pronunciation using a {target_accent} in the {language_name} language. "
         f"Specific Style Guidance: {tts_instruction_suffix}" # Append style-specific instructions
     )
     logger.info(f"Using Rich TTS instruction: {instruction_text}")

--- a/backend/services/visualization_service.py
+++ b/backend/services/visualization_service.py
@@ -47,11 +47,13 @@ async def generate_mermaid_visualization(
         logger.info(f"Requesting Mermaid visualization from LLM for submodule: {submodule_title}")
         
         # Generate response
+        from backend.utils.language_utils import get_full_language_name
+        language_name = get_full_language_name(language)
         response_text = await chain.ainvoke({
             "submodule_title": submodule_title,
             "submodule_description": submodule_description or "No description provided",
             "submodule_content": submodule_content[:15000],  # Limit content length for LLM
-            "language": language,
+            "language": language_name,
         })
 
         # Try to parse as JSON first (for "not suitable" message)

--- a/backend/utils/language_utils.py
+++ b/backend/utils/language_utils.py
@@ -1,0 +1,40 @@
+LANGUAGE_MAP = {
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "zh": "Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "ar": "Arabic",
+    "hi": "Hindi",
+    "bn": "Bengali",
+    "pa": "Punjabi",
+    "jv": "Javanese",
+    "id": "Indonesian",
+    "tr": "Turkish",
+    "vi": "Vietnamese",
+    "pl": "Polish",
+    "uk": "Ukrainian",
+    "nl": "Dutch",
+    "el": "Greek",
+    "cs": "Czech",
+    "sv": "Swedish",
+    "hu": "Hungarian",
+    "fi": "Finnish",
+    "no": "Norwegian",
+    "da": "Danish",
+    "th": "Thai",
+    "he": "Hebrew",
+    "ca": "Catalan",
+}
+
+def get_full_language_name(language_code: str) -> str:
+    """Return the full language name for a given ISO code."""
+    if "-" in language_code:
+        base_code = language_code.split("-")[0]
+        return LANGUAGE_MAP.get(base_code, language_code)
+    return LANGUAGE_MAP.get(language_code, language_code)


### PR DESCRIPTION
## Summary
- ensure full language names are provided to prompts and TTS
- centralise language code lookup in `language_utils`
- update audio, visualization and graph nodes to use new helper
- import helper in chatbot route

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685597b12e18832d888de11f7a774898