### PR TITLE
Refactor submodule research loop

### DIFF
--- a/backend/core/graph_nodes/__init__.py
+++ b/backend/core/graph_nodes/__init__.py
@@ -20,8 +20,7 @@ from .submodules import (
     develop_submodule_specific_content,
     finalize_enhanced_learning_path,
     check_submodule_batch_processing,
-    # Content refinement loop functions (following Google pattern)
-    develop_submodule_content_with_refinement_loop,
+    # Legacy content refinement functions (no longer used in default flow)
     evaluate_content_sufficiency,
     check_content_adequacy,
     check_content_adequacy_local,

--- a/backend/prompts/learning_path_prompts.py
+++ b/backend/prompts/learning_path_prompts.py
@@ -698,6 +698,54 @@ Provide a clear explanation of how your query set:
 """
 
 # =========================================================================
+# Submodule Research Evaluation Prompts (Google-Style Pattern)
+# =========================================================================
+
+SUBMODULE_RESEARCH_EVALUATION_PROMPT = """# EXPERT SUBMODULE RESEARCH EVALUATOR
+
+You are reviewing collected web research to determine if there is enough
+information to write high-quality educational content for the submodule
+"{submodule_title}" in the module "{module_title}" of the course about
+"{user_topic}".
+
+## LANGUAGE INSTRUCTIONS
+- Provide your analysis in {language}.
+
+## EVALUATION CRITERIA
+- Coverage of the submodule description and depth level
+- Diversity and credibility of sources
+- Overall sufficiency to write a detailed explanation
+
+Summarize missing areas as **knowledge gaps** if the research is insufficient.
+
+{format_instructions}
+
+## CURRENT RESEARCH SUMMARY
+{search_results_summary}
+"""
+
+SUBMODULE_REFINEMENT_QUERY_GENERATION_PROMPT = """# SUBMODULE RESEARCH REFINEMENT
+
+Generate additional search queries to fill the knowledge gaps for the submodule
+"{submodule_title}" of module "{module_title}" in the course on "{user_topic}".
+
+## LANGUAGE INSTRUCTIONS
+- Write your analysis in {language}
+- Formulate search queries in {search_language}
+
+## KNOWLEDGE GAPS
+{knowledge_gaps}
+
+## EXISTING QUERIES
+{existing_queries}
+
+Provide 1-3 concise follow-up queries that address the gaps without duplicating
+existing searches.
+
+{format_instructions}
+"""
+
+# =========================================================================
 # Submodule Chatbot Prompts
 # =========================================================================
 


### PR DESCRIPTION
## Summary
- add prompts for evaluating and refining submodule research
- add functions to run research-evaluation loop before writing content
- gather more research when needed and only then develop submodule content
- update module exports accordingly

## Testing
- `pip install -q -r requirements.txt`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6855edd7eb84832db0c598c069a7da98