### PR TITLE
Fix Dependabot alert for qs arrayLimit bypass

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10591,22 +10591,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -18462,13 +18446,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,8 @@
     "ajv": "^8.17.1",
     "ajv-keywords": "^5.1.0",
     "node-forge": "^1.3.2",
-    "express": "^4.22.0"
+    "express": "^4.22.0",
+    "qs": ">=6.14.1"
   },
   "jest": {
     "transformIgnorePatterns": [


### PR DESCRIPTION
…it bypass)

Add qs override in package.json to force version >=6.14.1 across all transitive dependencies (body-parser, express). This fixes the arrayLimit bypass vulnerability that allows DoS via memory exhaustion when parsing bracket notation arrays (a[]=x).

Fixes Dependabot alert #27

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Security bump to ensure safe `qs` resolution across the frontend.
> 
> - Adds `"qs": ">=6.14.1"` to `overrides` in `frontend/package.json` (alongside `express`)
> - Updates `package-lock.json` to resolve `qs@6.14.1` and its `side-channel` dep, and removes the nested `express/node_modules/qs` entry
> 
> Addresses Dependabot alert for the `qs` arrayLimit bypass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab745085e30ae61e47373af40d27cc03bd8d3a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->