### PR TITLE
Fix unsanitized class attribute in mdast-util-to-hast

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15044,9 +15044,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,8 @@
     "ajv-keywords": "^5.1.0",
     "node-forge": "^1.3.2",
     "express": "^4.22.0",
-    "qs": ">=6.14.1"
+    "qs": ">=6.14.1",
+    "mdast-util-to-hast": ">=13.2.1"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "bugs": {
     "url": "https://github.com/pma1999/mapmylearn/issues"
   },
-  "homepage": "https://github.com/pma1999/mapmylearn#readme"
+  "homepage": "https://github.com/pma1999/mapmylearn#readme",
+  "overrides": {
+    "mdast-util-to-hast": ">=13.2.1"
+  }
 }


### PR DESCRIPTION
…ss attribute vulnerability

Add npm override to force mdast-util-to-hast >= 13.2.1 which patches a security issue where unprefixed classnames could be added via markdown using character references (e.g., ```js&#x20;xss``). This could allow user-supplied markdown to add arbitrary CSS classes like .xss to code elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses a dependency security issue by enforcing a patched version of `mdast-util-to-hast`.
> 
> - Adds npm `overrides` in root and `frontend/package.json` to require `mdast-util-to-hast >= 13.2.1`
> - Updates root and frontend lockfiles to resolve `mdast-util-to-hast` to `13.2.1`
> - No application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 423f54203d730a0e5358e24671381e6c2059e2ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->